### PR TITLE
Remove gmock-all.cc and gtest-all.cc from build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -29,7 +29,6 @@ static_library("gmock_main") {
 
 static_library("gmock") {
   sources = [
-    "$dist/googlemock/src/gmock-all.cc",
     "$dist/googlemock/src/gmock-cardinalities.cc",
     "$dist/googlemock/src/gmock-internal-utils.cc",
     "$dist/googlemock/src/gmock-matchers.cc",
@@ -43,7 +42,6 @@ static_library("gmock") {
 
 static_library("gtest") {
   sources = [
-    "$dist/googletest/src/gtest-all.cc",
     "$dist/googletest/src/gtest-death-test.cc",
     "$dist/googletest/src/gtest-filepath.cc",
     "$dist/googletest/src/gtest-internal-inl.h",


### PR DESCRIPTION
Not sure why this even links.  gmock-all.cc and gtest-all.cc include all of the other .cc files, which are already included by the build config, so everything is compiled twice.  This is causing VS to fail to link due to all of the symbols being duplicated.