### PR TITLE
Pull C++20 fix from upstream.

### DIFF
--- a/googletest-1.10.0/googlemock/include/gmock/gmock-actions.h
+++ b/googletest-1.10.0/googlemock/include/gmock/gmock-actions.h
@@ -816,7 +816,8 @@ struct InvokeMethodWithoutArgsAction {
   Class* const obj_ptr;
   const MethodPtr method_ptr;
 
-  using ReturnType = typename std::result_of<MethodPtr(Class*)>::type;
+  using ReturnType =
+    decltype((std::declval<Class*>()->*std::declval<MethodPtr>())());
 
   template <typename... Args>
   ReturnType operator()(const Args&...) const {


### PR DESCRIPTION
The required std::result_of overload for doing this is deprecated, and in C++20 it's gone.  VS can't compile like this because it requires C++20 enabled for other things.